### PR TITLE
Skip coverage upload when CODECOV_TOKEN is not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,12 @@ jobs:
         uv run pytest --cov-report=xml --cov=xlsxlite xlsxlite
 
     - name: Upload coverage
-      if: success()
+      if: success() && env.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
         fail_ci_if_error: true
 
   release:


### PR DESCRIPTION
Gates the codecov upload step on the presence of the `CODECOV_TOKEN` secret so runs without it (e.g. forks) don't fail the build. When the token is set, `fail_ci_if_error: true` still catches genuine upload failures.